### PR TITLE
Added a "Disable Description" checkbox on notifications

### DIFF
--- a/Emby.Plugin.TelegramNotification/Configuration/entryeditor.js
+++ b/Emby.Plugin.TelegramNotification/Configuration/entryeditor.js
@@ -9,6 +9,7 @@
         entry.FriendlyName = context.querySelector('.txtFriendlyName').value;
         entry.Options.BotToken = context.querySelector('.txtTeleGramBotKey').value;
         entry.Options.ChatID = context.querySelector('.txtTeleGramChatID').value;
+        entry.Options.DisableDescription = context.querySelector('.chkDisableDescription').checked;
     };
 
     EntryEditor.setFormValues = function (context, entry) {
@@ -16,6 +17,7 @@
         context.querySelector('.txtFriendlyName').value = entry.FriendlyName || '';
         context.querySelector('.txtTeleGramBotKey').value = entry.Options.BotToken || '';
         context.querySelector('.txtTeleGramChatID').value = entry.Options.ChatID || '';
+        context.querySelector('.chkDisableDescription').checked = entry.Options.DisableDescription || false;
     };
 
     EntryEditor.loadTemplate = function (context) {

--- a/Emby.Plugin.TelegramNotification/Configuration/entryeditor.js
+++ b/Emby.Plugin.TelegramNotification/Configuration/entryeditor.js
@@ -9,7 +9,7 @@
         entry.FriendlyName = context.querySelector('.txtFriendlyName').value;
         entry.Options.BotToken = context.querySelector('.txtTeleGramBotKey').value;
         entry.Options.ChatID = context.querySelector('.txtTeleGramChatID').value;
-        entry.Options.DisableDescription = context.querySelector('.chkDisableDescription').checked;
+        entry.Options.DisableDescription = '' + context.querySelector('.chkDisableDescription').checked;
     };
 
     EntryEditor.setFormValues = function (context, entry) {
@@ -17,7 +17,7 @@
         context.querySelector('.txtFriendlyName').value = entry.FriendlyName || '';
         context.querySelector('.txtTeleGramBotKey').value = entry.Options.BotToken || '';
         context.querySelector('.txtTeleGramChatID').value = entry.Options.ChatID || '';
-        context.querySelector('.chkDisableDescription').checked = entry.Options.DisableDescription || false;
+        context.querySelector('.chkDisableDescription').checked = entry.Options.DisableDescription == "true" || false;
     };
 
     EntryEditor.loadTemplate = function (context) {

--- a/Emby.Plugin.TelegramNotification/Configuration/entryeditor.template.html
+++ b/Emby.Plugin.TelegramNotification/Configuration/entryeditor.template.html
@@ -15,9 +15,11 @@
         Telegram chat ID, get it from @get_id_bot
     </div>
 </div>
-<label class="emby-checkbox-label">
-    <input is="emby-checkbox" type="checkbox" class="chkDisableDescription"/>
-    <span class="checkboxLabel">
-        Disable Description
-    </span>
-</label>
+<div class="inputContainer">
+    <label class="emby-checkbox-label">
+        <input is="emby-checkbox" type="checkbox" class="chkDisableDescription"/>
+        <span class="checkboxLabel">
+            Disable Description
+        </span>
+    </label>
+</div>

--- a/Emby.Plugin.TelegramNotification/Configuration/entryeditor.template.html
+++ b/Emby.Plugin.TelegramNotification/Configuration/entryeditor.template.html
@@ -15,3 +15,9 @@
         Telegram chat ID, get it from @get_id_bot
     </div>
 </div>
+<label class="emby-checkbox-label">
+    <input is="emby-checkbox" type="checkbox" class="chkDisableDescription"/>
+    <span class="checkboxLabel">
+        Disable Description
+    </span>
+</label>

--- a/Emby.Plugin.TelegramNotification/Notifier.cs
+++ b/Emby.Plugin.TelegramNotification/Notifier.cs
@@ -39,10 +39,11 @@ namespace Emby.Plugin.TelegramNotification
 
             options.TryGetValue("BotToken", out string botToken);
             options.TryGetValue("ChatID", out string chatID);
+            options.TryGetValue("DisableDescription", out string disableDescription);
 
             string message = (request.Title);
 
-            if (string.IsNullOrEmpty(request.Description) == false)
+            if (string.IsNullOrEmpty(request.Description) == false && disableDescription != "true")
             {
                 message = (request.Title + "\n\n" + request.Description); 
             }


### PR DESCRIPTION
# Description
In this pull request, I have added a checkbox feature that allows users to disable the inclusion of descriptions in notifications. This is particularly useful in cases where the description may not be necessary or desired.

## Reasoning
Descriptions are a valuable feature, especially when new media, such as TV shows or anime, is added. However, there are situations where this information can be tedious or spoil the content, particularly for TV shows. Additionally, having descriptions for every notification can make the chat experience feel cluttered and overwhelming.

## Implementation
Added a checkbox option in the notification settings.
When the checkbox is checked, descriptions will not be included in notifications. (Default behaviour: unchecked)

## Benefits
Provides users with control over the content of their notifications.
Helps avoid spoilers for sensitive content.
Reduces the overall amount of text in chat, making it less heavy and more user-friendly.


Please review the changes and let me know if there are any adjustments or improvements needed.

Thank you!